### PR TITLE
Updated harvest.yml with notes and safer defaults

### DIFF
--- a/app/views/sites/_harvest.yml.haml
+++ b/app/views/sites/_harvest.yml.haml
@@ -17,8 +17,8 @@ site_id: #{@site.id}
 ~''
 \# this is the timezone for all the recordings.
 \# the value should be the timezone offset that
-\# the recorded was set to when it started recording.
-\# example: `utc_offset: '+10'`
+\# the recorder was set to when it started recording.
+\# example: `utc_offset: '+10'` for Brisbane, Australia
 utc_offset: 'INTENTIONALLY_INVALID'
 ~''
 \# structured metadata to add to each recording.

--- a/app/views/sites/_harvest.yml.haml
+++ b/app/views/sites/_harvest.yml.haml
@@ -15,8 +15,11 @@ site_id: #{@site.id}
   - else
     \#uploader_id: #{writer.id} # #{writer.user_name}
 ~''
-\# this is the timezone for all the recordings
-utc_offset: '+10'
+\# this is the timezone for all the recordings.
+\# the value should be the timezone offset that
+\# the recorded was set to when it started recording.
+\# example: `utc_offset: '+10'`
+utc_offset: 'INTENTIONALLY_INVALID'
 ~''
 \# structured metadata to add to each recording.
 \# use this to record information about sensors, etc...


### PR DESCRIPTION
Leaving the utc_offset invalid reduces the chances that invalid data will be ingested and forces the harvester to sanity check timezone offsets.